### PR TITLE
Add Mica effect and customizable tint for other Windows effects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tauri = { version = "1.0.0-rc.3", default-features = false, features = [], optio
   features = [
   "Win32_Foundation",
   "Win32_System_LibraryLoader",
+  "Win32_System_Registry",
   "Win32_System_SystemInformation",
   "Win32_Graphics_Gdi",
   "Win32_Graphics_Dwm",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ tauri-plugin-vibrancy = { git = "https://github.com/tauri-apps/tauri-plugin-vibr
 
         use tauri_plugin_vibrancy::Vibrancy;
         #[cfg(target_os = "windows")]
-        window.apply_blur();
+        window.apply_blur(Some(0x80121212u32));
         #[cfg(target_os = "macos")]
         {
             use tauri_plugin_vibrancy::MacOSVibrancy;
@@ -47,7 +47,7 @@ tauri-plugin-vibrancy = { git = "https://github.com/tauri-apps/tauri-plugin-vibr
 
         use tauri_plugin_vibrancy::Vibrancy;
         #[cfg(target_os = "windows")]
-        window.apply_blur();
+        window.apply_blur(Some(0x80121212u32));
         #[cfg(target_os = "macos")]
         {
             use tauri_plugin_vibrancy::MacOSVibrancy;
@@ -58,11 +58,7 @@ tauri-plugin-vibrancy = { git = "https://github.com/tauri-apps/tauri-plugin-vibr
 ## Available methods
 
 > Please read the methods documentation in [src/lib.rs](src/lib.rs)
-- `apply_blur()` - **`Windows`**
-- `apply_acrylic()` - **`Windows`** works on Windows 10 v1809 and above and has bad performance when resizing/dragging the window
+- `apply_blur()` - **`Windows`** and has bad performance when resizing/dragging the window
+- `apply_acrylic()` - **`Windows`** works on Windows 10 v1809 and above
+- `apply_mica()` - **`Windows`** works on Windows 11
 - `apply_vibrancy()` - **`macOS`** thanks to [@youngsing](https://github.com/youngsing)
-
-## TODOS
-
-- [ ] `apply_mica()` for Windows 11
-

--- a/examples/tauri/src-tauri/src/main.rs
+++ b/examples/tauri/src-tauri/src/main.rs
@@ -11,7 +11,7 @@ fn main() {
     .setup(|app| {
       let window = app.get_window("main").unwrap();
       #[cfg(target_os = "windows")]
-      window.apply_blur();
+      window.apply_acrylic(Some(0xBF121010u32));
       #[cfg(target_os = "macos")]
       {
         use tauri_plugin_vibrancy::MacOSVibrancy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,12 @@ use tao::platform::windows::WindowExtWindows;
 use tao::window::Window as TaoWindow;
 
 pub trait Vibrancy {
-  /// Applies Acrylic effect to you tao/tauri window. This has no effect on Windows versions below Windows 10 v1809
+  /// Applies Acrylic effect to you tao/tauri window with an optional tint in ABGR format. This has no effect on
+  /// Windows versions below Windows 10 v1809
+  #[cfg(target_os = "windows")]
+  fn apply_acrylic(&self, tint: Option<u32>);
+
+  /// Applies blur effect to tao/tauri window with an optional tint in ABGR format. (tint only supported on Windows 8+).
   ///
   /// ## WARNING:
   ///
@@ -68,11 +73,11 @@ pub trait Vibrancy {
   /// It is an issue in the undocumented api used for this method
   /// and microsoft needs to fix it (they probably won't).
   #[cfg(target_os = "windows")]
-  fn apply_acrylic(&self);
+  fn apply_blur(&self, tint: Option<u32>);
 
-  /// Applies blur effect to tao/tauri window.
+  /// Applies Mica effect to tao/tauri window. The mica effect is not tintable and requires Windows 11.
   #[cfg(target_os = "windows")]
-  fn apply_blur(&self);
+  fn apply_mica(&self);
 
   /// Applies macos vibrancy effect to tao/tauri window. This has no effect on macOS versions below 10.10
   #[cfg(target_os = "macos")]
@@ -85,13 +90,18 @@ where
   R: Runtime,
 {
   #[cfg(target_os = "windows")]
-  fn apply_acrylic(&self) {
-    windows::apply_acrylic(windows::HWND(self.hwnd().unwrap() as _));
+  fn apply_acrylic(&self, tint: Option<u32>) {
+    windows::apply_acrylic(windows::HWND(self.hwnd().unwrap() as _), tint);
   }
 
   #[cfg(target_os = "windows")]
-  fn apply_blur(&self) {
-    windows::apply_blur(windows::HWND(self.hwnd().unwrap() as _));
+  fn apply_blur(&self, tint: Option<u32>) {
+    windows::apply_blur(windows::HWND(self.hwnd().unwrap() as _), tint);
+  }
+
+  #[cfg(target_os = "windows")]
+  fn apply_mica(&self) {
+    windows::apply_mica(windows::HWND(self.hwnd().unwrap() as _));
   }
 
   #[cfg(target_os = "macos")]
@@ -103,13 +113,18 @@ where
 #[cfg(feature = "tao-impl")]
 impl Vibrancy for TaoWindow {
   #[cfg(target_os = "windows")]
-  fn apply_acrylic(&self) {
-    windows::apply_acrylic(windows::HWND(self.hwnd() as _));
+  fn apply_acrylic(&self, tint: Option<u32>) {
+    windows::apply_acrylic(windows::HWND(self.hwnd() as _), tint);
   }
 
   #[cfg(target_os = "windows")]
-  fn apply_blur(&self) {
-    windows::apply_blur(windows::HWND(self.hwnd() as _));
+  fn apply_blur(&self, tint: Option<u32>) {
+    windows::apply_blur(windows::HWND(self.hwnd() as _), tint);
+  }
+
+  #[cfg(target_os = "windows")]
+  fn apply_mica(&self) {
+    windows::apply_mica(windows::HWND(self.hwnd() as _));
   }
 
   #[cfg(target_os = "macos")]


### PR DESCRIPTION
This PR adds the Mica effect for Windows 11 devices and allows users to customize the tint color for acrylic & blur behind effects, fixing #1 and #17.

I also updated the documentation for `apply_acrylic` and `apply_blur`; from my experiences on 2 Windows 11 devices and from the info in #3, `apply_blur` has caused significantly more lag than `apply_acrylic`, contrary to what the docs suggest. I believe the doc notes for the lag issue were accidentally swapped.