### PR TITLE
feat(Windows): add functions to clear effects

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,20 @@ pub fn apply_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<
   }
 }
 
+pub fn clear_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
+  match window.raw_window_handle() {
+    #[cfg(target_os = "windows")]
+    raw_window_handle::RawWindowHandle::Win32(handle) => {
+      windows::clear_mica(handle.hwnd as _);
+      Ok(())
+    }
+    _ => Err(Error::UnsupportedPlatform(
+      "clear_mica()".into(),
+      "Windows".into(),
+    )),
+  }
+}
+
 /// Clears all Windows effects applied to window.
 pub fn clear_effects(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
   match window.raw_window_handle() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,21 @@ pub fn apply_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<
   }
 }
 
+/// Clears all Windows effects applied to window.
+pub fn clear_effects(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
+  match window.raw_window_handle() {
+    #[cfg(target_os = "windows")]
+    raw_window_handle::RawWindowHandle::Win32(handle) => {
+      windows::clear_effects(handle.hwnd as _);
+      Ok(())
+    }
+    _ => Err(Error::UnsupportedPlatform(
+      "clear_effects()".into(),
+      "Windows".into(),
+    )),
+  }
+}
+
 /// Applies macos vibrancy effect to window. This has no effect on macOS versions below 10.10
 pub fn apply_vibrancy(
   window: impl raw_window_handle::HasRawWindowHandle,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ pub fn clear_acrylic(window: impl raw_window_handle::HasRawWindowHandle) -> Resu
   }
 }
 
+/// Clears mica effect applied to window
 pub fn clear_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
   match window.raw_window_handle() {
     #[cfg(target_os = "windows")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ pub fn apply_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<
   }
 }
 
+/// Clears mica effect applied to window
 pub fn clear_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
   match window.raw_window_handle() {
     #[cfg(target_os = "windows")]
@@ -96,7 +97,7 @@ pub fn clear_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<
   }
 }
 
-/// Clears all Windows effects applied to window.
+/// Clears all Windows 10 effects applied to window.
 pub fn clear_effects(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
   match window.raw_window_handle() {
     #[cfg(target_os = "windows")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,37 @@ pub fn apply_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<
   }
 }
 
-/// Clears mica effect applied to window
+
+/// Clears blur effect applied to window
+pub fn clear_blur(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
+  match window.raw_window_handle() {
+    #[cfg(target_os = "windows")]
+    raw_window_handle::RawWindowHandle::Win32(handle) => {
+      windows::clear_blur(handle.hwnd as _);
+      Ok(())
+    }
+    _ => Err(Error::UnsupportedPlatform(
+      "clear_blur()".into(),
+      "Windows".into(),
+    )),
+  }
+}
+
+/// Clears acrylic effect applied to window
+pub fn clear_acrylic(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
+  match window.raw_window_handle() {
+    #[cfg(target_os = "windows")]
+    raw_window_handle::RawWindowHandle::Win32(handle) => {
+      windows::clear_acrylic(handle.hwnd as _);
+      Ok(())
+    }
+    _ => Err(Error::UnsupportedPlatform(
+      "clear_acrylic()".into(),
+      "Windows".into(),
+    )),
+  }
+}
+
 pub fn clear_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
   match window.raw_window_handle() {
     #[cfg(target_os = "windows")]
@@ -97,20 +127,6 @@ pub fn clear_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<
   }
 }
 
-/// Clears all Windows 10 effects applied to window.
-pub fn clear_effects(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
-  match window.raw_window_handle() {
-    #[cfg(target_os = "windows")]
-    raw_window_handle::RawWindowHandle::Win32(handle) => {
-      windows::clear_effects(handle.hwnd as _);
-      Ok(())
-    }
-    _ => Err(Error::UnsupportedPlatform(
-      "clear_effects()".into(),
-      "Windows".into(),
-    )),
-  }
-}
 
 /// Applies macos vibrancy effect to window. This has no effect on macOS versions below 10.10
 pub fn apply_vibrancy(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,6 @@ pub fn apply_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<
   }
 }
 
-
 /// Clears blur effect applied to window
 pub fn clear_blur(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
   match window.raw_window_handle() {
@@ -127,7 +126,6 @@ pub fn clear_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<
     )),
   }
 }
-
 
 /// Applies macos vibrancy effect to window. This has no effect on macOS versions below 10.10
 pub fn apply_vibrancy(

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -64,6 +64,24 @@ pub fn apply_mica(hwnd: HWND) {
   }
 }
 
+pub fn clear_effects(hwnd: HWND) {
+  if is_win7() {
+    let bb = DWM_BLURBEHIND {
+      dwFlags: DWM_BB_ENABLE,
+      fEnable: false.into(),
+      hRgnBlur: HRGN::default(),
+      fTransitionOnMaximized: 0,
+    };
+    unsafe {
+      let _ = DwmEnableBlurBehindWindow(hwnd, &bb);
+    }
+  } else {
+    unsafe {
+      set_window_composition_attribute(hwnd, AccentState::Nothing);
+    }
+  }
+}
+
 fn get_function_impl(library: &str, function: &str) -> Option<FARPROC> {
   assert_eq!(library.chars().last(), Some('\0'));
   assert_eq!(function.chars().last(), Some('\0'));
@@ -132,6 +150,7 @@ struct WINDOWCOMPOSITIONATTRIBDATA {
 }
 
 pub enum AccentState {
+  Nothing = 0,
   EnableBlurBehind = 3,
   EnableAcrylicBlurBehind = 4,
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -84,20 +84,21 @@ pub fn clear_blur(hwnd: HWND) {
 }
 
 pub fn clear_acrylic(hwnd: HWND) {
-  if is_win7() {
-    let bb = DWM_BLURBEHIND {
-      dwFlags: DWM_BB_ENABLE,
-      fEnable: false.into(),
-      hRgnBlur: HRGN::default(),
-      fTransitionOnMaximized: 0,
-    };
+  if is_win11_dwmsbt() {
     unsafe {
-      let _ = DwmEnableBlurBehindWindow(hwnd, &bb);
+      DwmSetWindowAttribute(
+        hwnd,
+        DWMWA_USE_IMMERSIVE_DARK_MODE,
+        &(DWM_SYSTEMBACKDROP_TYPE::DWMSBT_DISABLE) as *const _ as _,
+        4,
+      );
     }
-  } else {
+  } else if is_supported_win10() || is_win11() {
     unsafe {
       set_window_composition_attribute(hwnd, AccentState::Disabled);
     }
+  } else {
+    eprintln!("\"clear_acrylic\" is only available on Windows 10 v1809 or newer");
   }
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -64,6 +64,25 @@ pub fn apply_mica(hwnd: HWND) {
   }
 }
 
+pub fn clear_mica(hwnd: HWND) {
+  if is_win11_dwmsbt() {
+    unsafe {
+      DwmSetWindowAttribute(
+        hwnd,
+        DWMWA_SYSTEMBACKDROP_TYPE,
+        &(DWM_SYSTEMBACKDROP_TYPE::DWMSBT_DISABLE as i32) as *const _ as _,
+        4,
+      );
+    }
+  } else if is_win11() {
+    unsafe {
+      DwmSetWindowAttribute(hwnd, DWMWA_MICA_EFFECT, &1 as *const _ as _, 4);
+    }
+  } else {
+    eprintln!("\"clear_mica\" is only available on Windows 11");
+  }
+}
+
 pub fn clear_effects(hwnd: HWND) {
   if is_win7() {
     let bb = DWM_BLURBEHIND {
@@ -181,6 +200,7 @@ const DWMWA_SYSTEMBACKDROP_TYPE: DWMWINDOWATTRIBUTE = 38i32;
 
 #[allow(unused)]
 enum DWM_SYSTEMBACKDROP_TYPE {
+  DWMSBT_DISABLE = 1,         // None
   DWMSBT_MAINWINDOW = 2,      // Mica
   DWMSBT_TRANSIENTWINDOW = 3, // Acrylic
   DWMSBT_TABBEDWINDOW = 4,    // Tabbed

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -64,26 +64,8 @@ pub fn apply_mica(hwnd: HWND) {
   }
 }
 
-pub fn clear_mica(hwnd: HWND) {
-  if is_win11_dwmsbt() {
-    unsafe {
-      DwmSetWindowAttribute(
-        hwnd,
-        DWMWA_SYSTEMBACKDROP_TYPE,
-        &(DWM_SYSTEMBACKDROP_TYPE::DWMSBT_DISABLE as i32) as *const _ as _,
-        4,
-      );
-    }
-  } else if is_win11() {
-    unsafe {
-      DwmSetWindowAttribute(hwnd, DWMWA_MICA_EFFECT, &1 as *const _ as _, 4);
-    }
-  } else {
-    eprintln!("\"clear_mica\" is only available on Windows 11");
-  }
-}
 
-pub fn clear_effects(hwnd: HWND) {
+pub fn clear_blur(hwnd: HWND) {
   if is_win7() {
     let bb = DWM_BLURBEHIND {
       dwFlags: DWM_BB_ENABLE,
@@ -96,8 +78,45 @@ pub fn clear_effects(hwnd: HWND) {
     }
   } else {
     unsafe {
-      set_window_composition_attribute(hwnd, AccentState::Nothing);
+      set_window_composition_attribute(hwnd, AccentState::Disabled);
     }
+  }
+}
+
+pub fn clear_acrylic(hwnd: HWND) {
+  if is_win7() {
+    let bb = DWM_BLURBEHIND {
+      dwFlags: DWM_BB_ENABLE,
+      fEnable: false.into(),
+      hRgnBlur: HRGN::default(),
+      fTransitionOnMaximized: 0,
+    };
+    unsafe {
+      let _ = DwmEnableBlurBehindWindow(hwnd, &bb);
+    }
+  } else {
+    unsafe {
+      set_window_composition_attribute(hwnd, AccentState::Disabled);
+    }
+  }
+}
+
+pub fn clear_mica(hwnd: HWND) {
+  if is_win11_dwmsbt() {
+    unsafe {
+      DwmSetWindowAttribute(
+        hwnd,
+        DWMWA_SYSTEMBACKDROP_TYPE,
+        &(DWM_SYSTEMBACKDROP_TYPE::DWMSBT_DISABLE as i32) as *const _ as _,
+        4,
+      );
+    }
+  } else if is_win11() {
+    unsafe {
+      DwmSetWindowAttribute(hwnd, DWMWA_MICA_EFFECT, &0 as *const _ as _, 4);
+    }
+  } else {
+    eprintln!("\"clear_mica\" is only available on Windows 11");
   }
 }
 
@@ -169,7 +188,7 @@ struct WINDOWCOMPOSITIONATTRIBDATA {
 }
 
 pub enum AccentState {
-  Nothing = 0,
+  Disabled = 0,
   EnableBlurBehind = 3,
   EnableAcrylicBlurBehind = 4,
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -64,7 +64,6 @@ pub fn apply_mica(hwnd: HWND) {
   }
 }
 
-
 pub fn clear_blur(hwnd: HWND) {
   if is_win7() {
     let bb = DWM_BLURBEHIND {


### PR DESCRIPTION
Saw someone request this on the tauri discord, and since I had already had a peek at the source, decided to add some functionality.


Adds functions to clear the vibrancy effects on Windows. (`clear_mica` and `clear_effects`)


Only tested on Windows 10, and it works perfectly for me using `apply_blur` and `apply_acrylic`.


Has not been tested on Win 7 or 11. Unsure if the non-dwmsbt block in `clear_mica` works. Not super acquainted with either and only have a win10 machine right now, so 7&11 may very well be non-functioning. 
