### PR TITLE
docs: add reference to example dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ apply_vibrancy(&window, NSVisualEffectMaterial::HudWindow, None, None).expect("U
 apply_blur(&window, Some((18, 18, 18, 125))).expect("Unsupported platform! 'apply_blur' is only supported on Windows");
 ```
 
+For a more complete example of usage with [tauri](https://tauri.app/), view the ['example'](/example) directory of this repository
+
 ## Available functions
 
 | Function                          | Supported platforms               | Notes |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ apply_vibrancy(&window, NSVisualEffectMaterial::HudWindow, None, None).expect("U
 apply_blur(&window, Some((18, 18, 18, 125))).expect("Unsupported platform! 'apply_blur' is only supported on Windows");
 ```
 
-For a more complete example of usage with [tauri](https://tauri.app/), view the ['example'](/example) directory of this repository
+For a more complete example of usage with [tauri](https://tauri.app/), see [`examples/tauri`](https://github.com/tauri-apps/window-vibrancy/tree/dev/examples/tauri).
 
 ## Available functions
 


### PR DESCRIPTION
I'm a rust beginner and had to refer to issues to see how to use with tauri. Found a reference to someone saying "refer to the examples" directory for a more complete example. So, I added the reference to the README so that people won't miss that an example for tauri was even present.