### PR TITLE
Add Mica Tabbed backdrop type support

### DIFF
--- a/.changes/tabbed.md
+++ b/.changes/tabbed.md
@@ -1,0 +1,5 @@
+---
+"window-vibrancy": "patch"
+---
+
+On Windows, add `apply_tabbed` and `clear_tabbed`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,9 @@ pub fn apply_tabbed(
 pub fn clear_tabbed(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
     match window.raw_window_handle() {
         #[cfg(target_os = "windows")]
-        raw_window_handle::RawWindowHandle::Win32(handle) => windows::clear_tabbed(handle.hwnd as _),
+        raw_window_handle::RawWindowHandle::Win32(handle) => {
+            windows::clear_tabbed(handle.hwnd as _)
+        }
         _ => Err(Error::UnsupportedPlatform(
             "\"clear_tabbed()\" is only supported on Windows.",
         )),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,47 @@ pub fn clear_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<
     }
 }
 
+/// Applies mica tabbed effect to window. Works only on Windows 11.
+///
+/// ## Arguments
+///
+/// - `dark`: If `None` is provide, it will match the system preference
+///
+/// ## Platform-specific
+///
+/// - **Linux / macOS**: Unsupported.
+pub fn apply_tabbed(
+    window: impl raw_window_handle::HasRawWindowHandle,
+    dark: Option<bool>,
+) -> Result<(), Error> {
+    #[cfg(not(target_os = "windows"))]
+    let _ = dark;
+    match window.raw_window_handle() {
+        #[cfg(target_os = "windows")]
+        raw_window_handle::RawWindowHandle::Win32(handle) => {
+            windows::apply_tabbed(handle.hwnd as _, dark)
+        }
+        _ => Err(Error::UnsupportedPlatform(
+            "\"apply_tabbed()\" is only supported on Windows.",
+        )),
+    }
+}
+
+/// Clears mica tabbed effect applied to window. Works only on Windows 11.
+///
+/// ## Platform-specific
+///
+/// - **Linux / macOS**: Unsupported.
+pub fn clear_tabbed(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
+    match window.raw_window_handle() {
+        #[cfg(target_os = "windows")]
+        raw_window_handle::RawWindowHandle::Win32(handle) => windows::clear_tabbed(handle.hwnd as _),
+        _ => Err(Error::UnsupportedPlatform(
+            "\"clear_tabbed()\" is only supported on Windows.",
+        )),
+    }
+}
+
 /// Applies macos vibrancy effect to window. Works only on macOS 10.10 or newer.
 ///
 /// ## Platform-specific

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -164,6 +164,53 @@ pub fn clear_mica(hwnd: HWND) -> Result<(), Error> {
     Ok(())
 }
 
+pub fn apply_tabbed(hwnd: HWND, dark: Option<bool>) -> Result<(), Error> {
+    if let Some(dark) = dark {
+        unsafe {
+            DwmSetWindowAttribute(
+                hwnd,
+                DWMWA_USE_IMMERSIVE_DARK_MODE,
+                &(dark as u32) as *const _ as _,
+                4,
+            );
+        }
+    }
+
+    if is_backdroptype_supported() {
+        unsafe {
+            DwmSetWindowAttribute(
+                hwnd,
+                DWMWA_SYSTEMBACKDROP_TYPE,
+                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_TABBEDWINDOW as *const _ as _,
+                4,
+            );
+        }
+    } else {
+        return Err(Error::UnsupportedPlatformVersion(
+            "\"apply_tabbed()\" is only available on Windows 11.",
+        ));
+    }
+    Ok(())
+}
+
+pub fn clear_tabbed(hwnd: HWND) -> Result<(), Error> {
+    if is_backdroptype_supported() {
+        unsafe {
+            DwmSetWindowAttribute(
+                hwnd,
+                DWMWA_SYSTEMBACKDROP_TYPE,
+                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_DISABLE as *const _ as _,
+                4,
+            );
+        }
+    } else {
+        return Err(Error::UnsupportedPlatformVersion(
+            "\"clear_tabbed()\" is only available on Windows 11.",
+        ));
+    }
+    Ok(())
+}
+
 fn get_function_impl(library: &str, function: &str) -> Option<FARPROC> {
     assert_eq!(library.chars().last(), Some('\0'));
     assert_eq!(function.chars().last(), Some('\0'));


### PR DESCRIPTION
This PR adds 2 new functions: `apply_tabbed` and `clear_tabbed`.

You can read more about Mica Tabbed (Mica Alt) here: [**Mica material**](https://learn.microsoft.com/windows/apps/design/style/mica "learn.microsoft.com/windows/apps/design/style/mica").