### PR TITLE
feat: Implement `std::error::Error` for `window_vibrancy::Error`

### DIFF
--- a/.changes/std-error.md
+++ b/.changes/std-error.md
@@ -1,0 +1,5 @@
+---
+"window-vibrancy": "patch"
+---
+
+`window_vibrancy::Error` implements [`std::error::Error`](https://doc.rust-lang.org/std/error/trait.Error.html).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,3 +241,5 @@ impl std::fmt::Display for Error {
         }
     }
 }
+
+impl std::error::Error for Error {}


### PR DESCRIPTION
[`Error` trait](https://doc.rust-lang.org/std/error/trait.Error.html) is a basic trait to indicate it is an error type. This is useful for crates which provide generic error handling like [anyhow](https://crates.io/crates/anyhow) since it can be converted into `anyhow::Error`.

```rust
use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};

fn main() -> anyhow::Result<()> {
    let window = ...;
    apply_vibrancy(window, NSVisualEffectMaterial::HudWindow, None, None)?;
    Ok(())
}
```

Currently an error like below happens on coercing the error type at the `?`:

```
error[E0277]: the trait bound `window_vibrancy::Error: StdError` is not satisfied
   --> src/foo.rs:10:88
    |
156 |         apply_vibrancy(webview.window(), NSVisualEffectMaterial::HudWindow, None, None)?;
    |                                                                                        ^ the trait `StdError` is not implemented for `window_vibrancy::Error`
    |
    = help: the following other types implement trait `FromResidual<R>`:
              <Result<T, F> as FromResidual<Yeet<E>>>
              <Result<T, F> as FromResidual<Result<std::convert::Infallible, E>>>
    = note: required for `anyhow::Error` to implement `std::convert::From<window_vibrancy::Error>`
    = note: required for `Result<WebView, anyhow::Error>` to implement `FromResidual<Result<std::convert::Infallible, window_vibrancy::Error>>`

For more information about this error, try `rustc --explain E0277`.
```