### PR TITLE
docs: add additional setup instructions for Tauri in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ apply_vibrancy(&window, NSVisualEffectMaterial::HudWindow, None, None).expect("U
 apply_blur(&window, Some((18, 18, 18, 125))).expect("Unsupported platform! 'apply_blur' is only supported on Windows");
 ```
 
+Don't forget to:
+* set `html, body { background: transparent }` see [index.html#L12](https://github.com/tauri-apps/window-vibrancy/blob/dev/examples/tauri/public/index.html#L12)
+* set `"windows": [ "transparent": true ]` see [tauri.conf.json#L57](https://github.com/tauri-apps/window-vibrancy/blob/dev/examples/tauri/src-tauri/tauri.conf.json#L57)
+* on **macos** set `"macOSPrivateApi": true` see [tauri.conf.json#L49](https://github.com/tauri-apps/window-vibrancy/blob/dev/examples/tauri/src-tauri/tauri.conf.json#L49)
+
 For a more complete example of usage with [tauri](https://tauri.app/), see [`examples/tauri`](https://github.com/tauri-apps/window-vibrancy/tree/dev/examples/tauri).
 
 ## Available functions

--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ apply_vibrancy(&window, NSVisualEffectMaterial::HudWindow, None, None).expect("U
 apply_blur(&window, Some((18, 18, 18, 125))).expect("Unsupported platform! 'apply_blur' is only supported on Windows");
 ```
 
-Don't forget to:
+### Tauri
+
+if you are using tauri, don't forget to:
+
 * set `html, body { background: transparent }` see [index.html#L12](https://github.com/tauri-apps/window-vibrancy/blob/dev/examples/tauri/public/index.html#L12)
-* set `"windows": [ "transparent": true ]` see [tauri.conf.json#L57](https://github.com/tauri-apps/window-vibrancy/blob/dev/examples/tauri/src-tauri/tauri.conf.json#L57)
+* set `"windows": [ { "transparent": true } ]` see [tauri.conf.json#L57](https://github.com/tauri-apps/window-vibrancy/blob/dev/examples/tauri/src-tauri/tauri.conf.json#L57)
 * on **macos** set `"macOSPrivateApi": true` see [tauri.conf.json#L49](https://github.com/tauri-apps/window-vibrancy/blob/dev/examples/tauri/src-tauri/tauri.conf.json#L49)
 
 For a more complete example of usage with [tauri](https://tauri.app/), see [`examples/tauri`](https://github.com/tauri-apps/window-vibrancy/tree/dev/examples/tauri).


### PR DESCRIPTION
I struggled for a good hour setting this up and I see [more people do so](https://github.com/tauri-apps/window-vibrancy/issues/48). This could have prevented my struggles.