### PR TITLE
feat(deps): update raw-window-handle to v0.6

### DIFF
--- a/.changes/rwh06.md
+++ b/.changes/rwh06.md
@@ -1,0 +1,5 @@
+---
+"window-vibrancy": minor
+---
+
+**Breaking change** Update `raw-window-handle` crate to 0.6. Now APIs require `HasWindowHandle` trait boundary instead of `HasRawWindowHandle`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,7 @@ raw-window-handle = "0.6"
 
 [dev-dependencies]
 tao = "0.25"
-winit = { version = "0.29", default-features = false, features = [
-  "x11",
-  "wayland",
-  "wayland-dlopen",
-  "wayland-csd-adwaita",
-  "rwh_06"
-] }
+winit = "0.29"
 
 [target."cfg(target_os = \"windows\")".dependencies]
 windows-version = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,16 @@ default-target = "x86_64-pc-windows-msvc"
 targets = [ "x86_64-apple-darwin", "x86_64-pc-windows-msvc" ]
 
 [dependencies]
-raw-window-handle = "0.5"
+raw-window-handle = "0.6"
 
 [dev-dependencies]
-tao = { version = "0.25", features = ["rwh_05"] }
+tao = "0.25"
 winit = { version = "0.29", default-features = false, features = [
   "x11",
   "wayland",
   "wayland-dlopen",
   "wayland-csd-adwaita",
-  "rwh_05"
+  "rwh_06"
 ] }
 
 [target."cfg(target_os = \"windows\")".dependencies]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 Make your windows vibrant.
 
+> [!Tip]
+> If you're using `tauri@v1`, you need to use version `0.4` of this crate.
+
 ## Platform-specific
 
 - **Linux**: Unsupported, Blur and any vibrancy effects are controlled by the compositor installed on the end-user system.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! ```no_run
 //! use window_vibrancy::{apply_vibrancy, apply_blur, NSVisualEffectMaterial};
 //!
-//! # let window: &dyn raw_window_handle::HasRawWindowHandle = unsafe { std::mem::zeroed() };
+//! # let window: &dyn raw_window_handle::HasWindowHandle = unsafe { std::mem::zeroed() };
 //! #[cfg(target_os = "macos")]
 //! apply_vibrancy(&window, NSVisualEffectMaterial::AppearanceBased, None, None).expect("Unsupported platform! 'apply_vibrancy' is only supported on macOS");
 //!
@@ -45,13 +45,13 @@ pub type Color = (u8, u8, u8, u8);
 /// - **Windows**: *`color`* is ignored on Windows 7 and has no effect.
 /// - **Linux / macOS**: Unsupported.
 pub fn apply_blur(
-    window: impl raw_window_handle::HasRawWindowHandle,
+    window: impl raw_window_handle::HasWindowHandle,
     #[allow(unused)] color: Option<Color>,
 ) -> Result<(), Error> {
-    match window.raw_window_handle() {
+    match window.window_handle()?.as_raw() {
         #[cfg(target_os = "windows")]
         raw_window_handle::RawWindowHandle::Win32(handle) => {
-            windows::apply_blur(handle.hwnd as _, color)
+            windows::apply_blur(handle.hwnd.get() as _, color)
         }
         _ => Err(Error::UnsupportedPlatform(
             "\"apply_blur()\" is only supported on Windows.",
@@ -64,10 +64,12 @@ pub fn apply_blur(
 /// ## Platform-specific
 ///
 /// - **Linux / macOS**: Unsupported.
-pub fn clear_blur(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
-    match window.raw_window_handle() {
+pub fn clear_blur(window: impl raw_window_handle::HasWindowHandle) -> Result<(), Error> {
+    match window.window_handle()?.as_raw() {
         #[cfg(target_os = "windows")]
-        raw_window_handle::RawWindowHandle::Win32(handle) => windows::clear_blur(handle.hwnd as _),
+        raw_window_handle::RawWindowHandle::Win32(handle) => {
+            windows::clear_blur(handle.hwnd.get() as _)
+        }
         _ => Err(Error::UnsupportedPlatform(
             "\"clear_blur()\" is only supported on Windows.",
         )),
@@ -88,13 +90,13 @@ pub fn clear_blur(window: impl raw_window_handle::HasRawWindowHandle) -> Result<
 /// - **Windows**: *`color`* is ignored on Windows 7 and has no effect.
 /// - **Linux / macOS**: Unsupported.
 pub fn apply_acrylic(
-    window: impl raw_window_handle::HasRawWindowHandle,
+    window: impl raw_window_handle::HasWindowHandle,
     #[allow(unused)] color: Option<Color>,
 ) -> Result<(), Error> {
-    match window.raw_window_handle() {
+    match window.window_handle()?.as_raw() {
         #[cfg(target_os = "windows")]
         raw_window_handle::RawWindowHandle::Win32(handle) => {
-            windows::apply_acrylic(handle.hwnd as _, color)
+            windows::apply_acrylic(handle.hwnd.get() as _, color)
         }
         _ => Err(Error::UnsupportedPlatform(
             "\"apply_acrylic()\" is only supported on Windows.",
@@ -107,11 +109,11 @@ pub fn apply_acrylic(
 /// ## Platform-specific
 ///
 /// - **Linux / macOS**: Unsupported.
-pub fn clear_acrylic(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
-    match window.raw_window_handle() {
+pub fn clear_acrylic(window: impl raw_window_handle::HasWindowHandle) -> Result<(), Error> {
+    match window.window_handle()?.as_raw() {
         #[cfg(target_os = "windows")]
         raw_window_handle::RawWindowHandle::Win32(handle) => {
-            windows::clear_acrylic(handle.hwnd as _)
+            windows::clear_acrylic(handle.hwnd.get() as _)
         }
         _ => Err(Error::UnsupportedPlatform(
             "\"clear_acrylic()\" is only supported on Windows.",
@@ -129,15 +131,15 @@ pub fn clear_acrylic(window: impl raw_window_handle::HasRawWindowHandle) -> Resu
 ///
 /// - **Linux / macOS**: Unsupported.
 pub fn apply_mica(
-    window: impl raw_window_handle::HasRawWindowHandle,
+    window: impl raw_window_handle::HasWindowHandle,
     dark: Option<bool>,
 ) -> Result<(), Error> {
     #[cfg(not(target_os = "windows"))]
     let _ = dark;
-    match window.raw_window_handle() {
+    match window.window_handle()?.as_raw() {
         #[cfg(target_os = "windows")]
         raw_window_handle::RawWindowHandle::Win32(handle) => {
-            windows::apply_mica(handle.hwnd as _, dark)
+            windows::apply_mica(handle.hwnd.get() as _, dark)
         }
         _ => Err(Error::UnsupportedPlatform(
             "\"apply_mica()\" is only supported on Windows.",
@@ -150,10 +152,12 @@ pub fn apply_mica(
 /// ## Platform-specific
 ///
 /// - **Linux / macOS**: Unsupported.
-pub fn clear_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
-    match window.raw_window_handle() {
+pub fn clear_mica(window: impl raw_window_handle::HasWindowHandle) -> Result<(), Error> {
+    match window.window_handle()?.as_raw() {
         #[cfg(target_os = "windows")]
-        raw_window_handle::RawWindowHandle::Win32(handle) => windows::clear_mica(handle.hwnd as _),
+        raw_window_handle::RawWindowHandle::Win32(handle) => {
+            windows::clear_mica(handle.hwnd.get() as _)
+        }
         _ => Err(Error::UnsupportedPlatform(
             "\"clear_mica()\" is only supported on Windows.",
         )),
@@ -170,15 +174,15 @@ pub fn clear_mica(window: impl raw_window_handle::HasRawWindowHandle) -> Result<
 ///
 /// - **Linux / macOS**: Unsupported.
 pub fn apply_tabbed(
-    window: impl raw_window_handle::HasRawWindowHandle,
+    window: impl raw_window_handle::HasWindowHandle,
     dark: Option<bool>,
 ) -> Result<(), Error> {
     #[cfg(not(target_os = "windows"))]
     let _ = dark;
-    match window.raw_window_handle() {
+    match window.window_handle()?.as_raw() {
         #[cfg(target_os = "windows")]
         raw_window_handle::RawWindowHandle::Win32(handle) => {
-            windows::apply_tabbed(handle.hwnd as _, dark)
+            windows::apply_tabbed(handle.hwnd.get() as _, dark)
         }
         _ => Err(Error::UnsupportedPlatform(
             "\"apply_tabbed()\" is only supported on Windows.",
@@ -191,11 +195,11 @@ pub fn apply_tabbed(
 /// ## Platform-specific
 ///
 /// - **Linux / macOS**: Unsupported.
-pub fn clear_tabbed(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), Error> {
-    match window.raw_window_handle() {
+pub fn clear_tabbed(window: impl raw_window_handle::HasWindowHandle) -> Result<(), Error> {
+    match window.window_handle()?.as_raw() {
         #[cfg(target_os = "windows")]
         raw_window_handle::RawWindowHandle::Win32(handle) => {
-            windows::clear_tabbed(handle.hwnd as _)
+            windows::clear_tabbed(handle.hwnd.get() as _)
         }
         _ => Err(Error::UnsupportedPlatform(
             "\"clear_tabbed()\" is only supported on Windows.",
@@ -209,15 +213,15 @@ pub fn clear_tabbed(window: impl raw_window_handle::HasRawWindowHandle) -> Resul
 ///
 /// - **Linux / Windows**: Unsupported.
 pub fn apply_vibrancy(
-    window: impl raw_window_handle::HasRawWindowHandle,
+    window: impl raw_window_handle::HasWindowHandle,
     #[allow(unused)] effect: NSVisualEffectMaterial,
     #[allow(unused)] state: Option<NSVisualEffectState>,
     #[allow(unused)] radius: Option<f64>,
 ) -> Result<(), Error> {
-    match window.raw_window_handle() {
+    match window.window_handle()?.as_raw() {
         #[cfg(target_os = "macos")]
         raw_window_handle::RawWindowHandle::AppKit(handle) => {
-            macos::apply_vibrancy(handle.ns_window as _, effect, state, radius)
+            macos::apply_vibrancy(handle.ns_view.as_ptr() as _, effect, state, radius)
         }
         _ => Err(Error::UnsupportedPlatform(
             "\"apply_vibrancy()\" is only supported on macOS.",
@@ -230,6 +234,7 @@ pub enum Error {
     UnsupportedPlatform(&'static str),
     UnsupportedPlatformVersion(&'static str),
     NotMainThread(&'static str),
+    NoWindowHandle(raw_window_handle::HandleError),
 }
 
 impl std::fmt::Display for Error {
@@ -240,8 +245,17 @@ impl std::fmt::Display for Error {
             | Error::NotMainThread(e) => {
                 write!(f, "{}", e)
             }
+            Error::NoWindowHandle(e) => {
+                write!(f, "{}", e)
+            }
         }
     }
 }
 
 impl std::error::Error for Error {}
+
+impl From<raw_window_handle::HandleError> for Error {
+    fn from(err: raw_window_handle::HandleError) -> Self {
+        Error::NoWindowHandle(err)
+    }
+}

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -79,7 +79,7 @@ mod internal {
     use cocoa::{
         appkit::{
             NSAppKitVersionNumber, NSAppKitVersionNumber10_10, NSAppKitVersionNumber10_11,
-            NSAutoresizingMaskOptions, NSView, NSViewHeightSizable, NSViewWidthSizable, NSWindow,
+            NSAutoresizingMaskOptions, NSView, NSViewHeightSizable, NSViewWidthSizable,
             NSWindowOrderingMode,
         },
         base::{id, nil, BOOL},
@@ -91,7 +91,7 @@ mod internal {
 
     #[allow(deprecated)]
     pub fn apply_vibrancy(
-        window: id,
+        ns_view: id,
         appearance: NSVisualEffectMaterial,
         state: Option<NSVisualEffectState>,
         radius: Option<f64>,
@@ -117,9 +117,7 @@ mod internal {
                 m = NSVisualEffectMaterial::AppearanceBased;
             }
 
-            let ns_view: id = window.contentView();
             let bounds = NSView::bounds(ns_view);
-
             let blurred_view =
                 NSVisualEffectView::initWithFrame_(NSVisualEffectView::alloc(nil), bounds);
             blurred_view.autorelease();

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -11,7 +11,7 @@ use std::ffi::c_void;
 pub use windows_sys::Win32::{
     Foundation::*,
     Graphics::{Dwm::*, Gdi::*},
-    System::{LibraryLoader::*, SystemInformation::*},
+    System::LibraryLoader::*,
 };
 
 use crate::{Color, Error};


### PR DESCRIPTION
Close #104 

I'm using this crate with wry. And wry recently migrated to raw-window-handle v0.6. However this crate is still using raw-window-handle v0.5 so currently this crate is not available with wry.

This PR updates raw-window-handle dependency from v0.5 to v0.6. This is a breaking change since APIs of this crate use `HasRawWindowHandle` trait exported from raw-window-handle.

I confirmed no regression with `tao` and `winit` examples on both macOS 13 and Windows 10.