### PR TITLE
Migrate from `objc`/`cocoa` to `objc2`

### DIFF
--- a/.changes/use-objc2.md
+++ b/.changes/use-objc2.md
@@ -1,0 +1,5 @@
+---
+"window-vibrancy": patch
+---
+
+Use `objc2` internally, leading to better memory safety.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "window-vibrancy"
 description = "Make your windows vibrant."
-authors = [ "Tauri Programme within The Commons Conservancy" ]
+authors = ["Tauri Programme within The Commons Conservancy"]
 version = "0.5.1"
 edition = "2021"
 rust-version = "1.56"
@@ -9,12 +9,12 @@ license = "Apache-2.0 OR MIT"
 readme = "README.md"
 repository = "https://github.com/tauri-apps/tauri-plugin-vibrancy"
 documentation = "https://docs.rs/tauri-plugin-vibrancy"
-keywords = [ "vibrancy", "acrylic", "mica", "blur", "windowing" ]
-categories = [ "gui" ]
+keywords = ["vibrancy", "acrylic", "mica", "blur", "windowing"]
+categories = ["gui"]
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
-targets = [ "x86_64-apple-darwin", "x86_64-pc-windows-msvc" ]
+targets = ["x86_64-apple-darwin", "x86_64-pc-windows-msvc"]
 
 [dependencies]
 raw-window-handle = "0.6"
@@ -23,20 +23,27 @@ raw-window-handle = "0.6"
 tao = "0.30"
 winit = "0.29"
 
-[target."cfg(target_os = \"windows\")".dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 windows-version = "0.1"
 
-  [target."cfg(target_os = \"windows\")".dependencies.windows-sys]
-  version = "0.59.0"
-  features = [
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+version = "0.59.0"
+features = [
   "Win32_Foundation",
   "Win32_System_LibraryLoader",
   "Win32_System_SystemInformation",
   "Win32_Graphics_Gdi",
   "Win32_Graphics_Dwm",
-  "Win32_UI_WindowsAndMessaging"
+  "Win32_UI_WindowsAndMessaging",
 ]
 
-[target."cfg(target_os = \"macos\")".dependencies]
-cocoa = "0.26"
-objc = "0.2"
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.5.2"
+objc2-app-kit = { version = "0.2.2", features = [
+  "NSApplication",
+  "NSGraphics",
+  "NSResponder",
+  "NSView",
+  "NSVisualEffectView",
+] }
+objc2-foundation = { version = "0.2.2", features = ["NSThread", "NSGeometry"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,9 +220,9 @@ pub fn apply_vibrancy(
 ) -> Result<(), Error> {
     match window.window_handle()?.as_raw() {
         #[cfg(target_os = "macos")]
-        raw_window_handle::RawWindowHandle::AppKit(handle) => {
-            macos::apply_vibrancy(handle.ns_view.as_ptr() as _, effect, state, radius)
-        }
+        raw_window_handle::RawWindowHandle::AppKit(handle) => unsafe {
+            macos::apply_vibrancy(handle.ns_view, effect, state, radius)
+        },
         _ => Err(Error::UnsupportedPlatform(
             "\"apply_vibrancy()\" is only supported on macOS.",
         )),

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -92,15 +92,14 @@ mod internal {
         state: Option<super::NSVisualEffectState>,
         radius: Option<f64>,
     ) -> Result<(), Error> {
-        let mtm = MainThreadMarker::new().ok_or_else(|| {
-            Error::NotMainThread("\"apply_vibrancy()\" can only be used on the main thread.")
-        })?;
+        let mtm = MainThreadMarker::new().ok_or(Error::NotMainThread(
+            "\"apply_vibrancy()\" can only be used on the main thread.",
+        ))?;
 
         unsafe {
             let view: &NSView = ns_view.cast().as_ref();
 
             if NSAppKitVersionNumber < NSAppKitVersionNumber10_10 {
-                eprintln!("\"NSVisualEffectView\" is only available on macOS 10.10 or newer");
                 return Err(Error::UnsupportedPlatformVersion(
                     "\"apply_vibrancy()\" is only available on macOS 10.0 or newer.",
                 ));


### PR DESCRIPTION
See https://github.com/tauri-apps/wry/issues/1239 and backreferences to https://github.com/madsmtm/objc2/issues/174 for context and details.

I decided to keep the `NSVisualEffectMaterial` and `NSVisualEffectState` definitions that this crate re-exports, since they're public API, and I didn't want to tie the public API to `objc2-app-kit`'s. Besides, `objc2-app-kit` has to use a newtype for soundness, while this crate can more easily use an `enum`.