### PR TITLE
chore: prepare for `objc2` frameworks v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,16 @@ features = [
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5.2"
-objc2-app-kit = { version = "0.2.2", features = [
+objc2-app-kit = { version = "0.2.2", default-features = false, features = [
+  "std",
   "NSApplication",
   "NSGraphics",
   "NSResponder",
   "NSView",
   "NSVisualEffectView",
 ] }
-objc2-foundation = { version = "0.2.2", features = ["NSThread", "NSGeometry"] }
+objc2-foundation = { version = "0.2.2", default-features = false, features = [
+  "std",
+  "NSThread",
+  "NSGeometry",
+] }


### PR DESCRIPTION
The next version of the `objc2` framework crates will have a bunch of default features enabled, see https://github.com/madsmtm/objc2/issues/627, so this PR pre-emptively disables them, so that your compile times down blow up once you upgrade to the next version (which is yet to be released, but will be soon).

I did not include a changelog entry here, since there are no user-facing changes, and since it doesn't need to be shipped to users.