### PR TITLE
fix(windows): Propagate errors from `DwmSetWindowAttribute()`

### DIFF
--- a/.changes/fix_win32_api_error_is_ignored.md
+++ b/.changes/fix_win32_api_error_is_ignored.md
@@ -2,4 +2,4 @@
 "window-vibrancy": patch
 ---
 
-Fix errors returned from `DwmSetWindowAttribute()` are ignored.
+propagate errors from `DwmSetWindowAttribute()` instead of ignoring it.

--- a/.changes/fix_win32_api_error_is_ignored.md
+++ b/.changes/fix_win32_api_error_is_ignored.md
@@ -1,0 +1,5 @@
+---
+"window-vibrancy": patch
+---
+
+Fix errors returned from `DwmSetWindowAttribute()` are ignored.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@
 
 #![allow(clippy::deprecated_semver)]
 
+#[cfg(target_os = "windows")]
+use windows_sys::core::HRESULT;
+
 mod macos;
 mod windows;
 
@@ -315,6 +318,11 @@ pub enum Error {
     UnsupportedPlatformVersion(&'static str),
     NotMainThread(&'static str),
     NoWindowHandle(raw_window_handle::HandleError),
+    #[cfg(target_os = "windows")]
+    Win32Error {
+        api: &'static str,
+        result: HRESULT,
+    },
 }
 
 impl std::fmt::Display for Error {
@@ -327,6 +335,14 @@ impl std::fmt::Display for Error {
             }
             Error::NoWindowHandle(e) => {
                 write!(f, "{}", e)
+            }
+            #[cfg(target_os = "windows")]
+            Error::Win32Error { api, result } => {
+                write!(
+                    f,
+                    "Win32 API {api}() returned the error result 0x{:x}.",
+                    result,
+                )
             }
         }
     }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -62,12 +62,11 @@ pub fn clear_blur(hwnd: HWND) -> Result<(), Error> {
 pub fn apply_acrylic(hwnd: HWND, color: Option<Color>) -> Result<(), Error> {
     if is_backdroptype_supported() {
         unsafe {
-            DwmSetWindowAttribute(
+            set_window_attribute(
                 hwnd,
                 DWMWA_SYSTEMBACKDROP_TYPE as _,
-                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_TRANSIENTWINDOW as *const _ as _,
-                4,
-            );
+                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_TRANSIENTWINDOW,
+            )?;
         }
     } else if is_swca_supported() {
         unsafe {
@@ -88,12 +87,11 @@ pub fn apply_acrylic(hwnd: HWND, color: Option<Color>) -> Result<(), Error> {
 pub fn clear_acrylic(hwnd: HWND) -> Result<(), Error> {
     if is_backdroptype_supported() {
         unsafe {
-            DwmSetWindowAttribute(
+            set_window_attribute(
                 hwnd,
                 DWMWA_SYSTEMBACKDROP_TYPE as _,
-                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_DISABLE as *const _ as _,
-                4,
-            );
+                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_DISABLE,
+            )?;
         }
     } else if is_swca_supported() {
         unsafe {
@@ -110,27 +108,21 @@ pub fn clear_acrylic(hwnd: HWND) -> Result<(), Error> {
 pub fn apply_mica(hwnd: HWND, dark: Option<bool>) -> Result<(), Error> {
     if let Some(dark) = dark {
         unsafe {
-            DwmSetWindowAttribute(
-                hwnd,
-                DWMWA_USE_IMMERSIVE_DARK_MODE as _,
-                &(dark as u32) as *const _ as _,
-                4,
-            );
+            set_window_attribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE as _, &(dark as u32))?;
         }
     }
 
     if is_backdroptype_supported() {
         unsafe {
-            DwmSetWindowAttribute(
+            set_window_attribute(
                 hwnd,
                 DWMWA_SYSTEMBACKDROP_TYPE as _,
-                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_MAINWINDOW as *const _ as _,
-                4,
-            );
+                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_MAINWINDOW,
+            )?;
         }
     } else if is_undocumented_mica_supported() {
         unsafe {
-            DwmSetWindowAttribute(hwnd, DWMWA_MICA_EFFECT as _, &1 as *const _ as _, 4);
+            set_window_attribute(hwnd, DWMWA_MICA_EFFECT as _, &1)?;
         }
     } else {
         return Err(Error::UnsupportedPlatformVersion(
@@ -143,16 +135,15 @@ pub fn apply_mica(hwnd: HWND, dark: Option<bool>) -> Result<(), Error> {
 pub fn clear_mica(hwnd: HWND) -> Result<(), Error> {
     if is_backdroptype_supported() {
         unsafe {
-            DwmSetWindowAttribute(
+            set_window_attribute(
                 hwnd,
                 DWMWA_SYSTEMBACKDROP_TYPE as _,
-                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_DISABLE as *const _ as _,
-                4,
-            );
+                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_DISABLE,
+            )?;
         }
     } else if is_undocumented_mica_supported() {
         unsafe {
-            DwmSetWindowAttribute(hwnd, DWMWA_MICA_EFFECT as _, &0 as *const _ as _, 4);
+            set_window_attribute(hwnd, DWMWA_MICA_EFFECT as _, &0)?;
         }
     } else {
         return Err(Error::UnsupportedPlatformVersion(
@@ -165,23 +156,17 @@ pub fn clear_mica(hwnd: HWND) -> Result<(), Error> {
 pub fn apply_tabbed(hwnd: HWND, dark: Option<bool>) -> Result<(), Error> {
     if let Some(dark) = dark {
         unsafe {
-            DwmSetWindowAttribute(
-                hwnd,
-                DWMWA_USE_IMMERSIVE_DARK_MODE as _,
-                &(dark as u32) as *const _ as _,
-                4,
-            );
+            set_window_attribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE as _, &(dark as u32))?;
         }
     }
 
-    if is_backdroptype_supported() {
+    if dbg!(is_backdroptype_supported()) {
         unsafe {
-            DwmSetWindowAttribute(
+            set_window_attribute(
                 hwnd,
                 DWMWA_SYSTEMBACKDROP_TYPE as _,
-                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_TABBEDWINDOW as *const _ as _,
-                4,
-            );
+                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_TABBEDWINDOW,
+            )?;
         }
     } else {
         return Err(Error::UnsupportedPlatformVersion(
@@ -194,12 +179,11 @@ pub fn apply_tabbed(hwnd: HWND, dark: Option<bool>) -> Result<(), Error> {
 pub fn clear_tabbed(hwnd: HWND) -> Result<(), Error> {
     if is_backdroptype_supported() {
         unsafe {
-            DwmSetWindowAttribute(
+            set_window_attribute(
                 hwnd,
                 DWMWA_SYSTEMBACKDROP_TYPE as _,
-                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_DISABLE as *const _ as _,
-                4,
-            );
+                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_DISABLE,
+            )?;
         }
     } else {
         return Err(Error::UnsupportedPlatformVersion(
@@ -288,6 +272,17 @@ unsafe fn SetWindowCompositionAttribute(
         };
 
         set_window_composition_attribute(hwnd, &mut data as *mut _ as _);
+    }
+}
+
+unsafe fn set_window_attribute<T>(hwnd: HWND, kind: u32, object: &T) -> Result<(), Error> {
+    let size = std::mem::size_of::<T>() as u32;
+    let result = unsafe { DwmSetWindowAttribute(hwnd, kind, object as *const _ as _, size) };
+    if result == S_OK {
+        Ok(())
+    } else {
+        let api = "DwmSetWindowAttribute";
+        Err(Error::Win32Error { api, result })
     }
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -65,7 +65,7 @@ pub fn apply_acrylic(hwnd: HWND, color: Option<Color>) -> Result<(), Error> {
             set_window_attribute(
                 hwnd,
                 DWMWA_SYSTEMBACKDROP_TYPE as _,
-                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_TRANSIENTWINDOW,
+                &DWMSBT_TRANSIENTWINDOW,
             )?;
         }
     } else if is_swca_supported() {
@@ -87,11 +87,7 @@ pub fn apply_acrylic(hwnd: HWND, color: Option<Color>) -> Result<(), Error> {
 pub fn clear_acrylic(hwnd: HWND) -> Result<(), Error> {
     if is_backdroptype_supported() {
         unsafe {
-            set_window_attribute(
-                hwnd,
-                DWMWA_SYSTEMBACKDROP_TYPE as _,
-                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_DISABLE,
-            )?;
+            set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_NONE)?;
         }
     } else if is_swca_supported() {
         unsafe {
@@ -114,11 +110,7 @@ pub fn apply_mica(hwnd: HWND, dark: Option<bool>) -> Result<(), Error> {
 
     if is_backdroptype_supported() {
         unsafe {
-            set_window_attribute(
-                hwnd,
-                DWMWA_SYSTEMBACKDROP_TYPE as _,
-                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_MAINWINDOW,
-            )?;
+            set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_MAINWINDOW)?;
         }
     } else if is_undocumented_mica_supported() {
         unsafe {
@@ -135,11 +127,7 @@ pub fn apply_mica(hwnd: HWND, dark: Option<bool>) -> Result<(), Error> {
 pub fn clear_mica(hwnd: HWND) -> Result<(), Error> {
     if is_backdroptype_supported() {
         unsafe {
-            set_window_attribute(
-                hwnd,
-                DWMWA_SYSTEMBACKDROP_TYPE as _,
-                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_DISABLE,
-            )?;
+            set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_NONE)?;
         }
     } else if is_undocumented_mica_supported() {
         unsafe {
@@ -162,11 +150,7 @@ pub fn apply_tabbed(hwnd: HWND, dark: Option<bool>) -> Result<(), Error> {
 
     if dbg!(is_backdroptype_supported()) {
         unsafe {
-            set_window_attribute(
-                hwnd,
-                DWMWA_SYSTEMBACKDROP_TYPE as _,
-                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_TABBEDWINDOW,
-            )?;
+            set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_TABBEDWINDOW)?;
         }
     } else {
         return Err(Error::UnsupportedPlatformVersion(
@@ -179,11 +163,7 @@ pub fn apply_tabbed(hwnd: HWND, dark: Option<bool>) -> Result<(), Error> {
 pub fn clear_tabbed(hwnd: HWND) -> Result<(), Error> {
     if is_backdroptype_supported() {
         unsafe {
-            set_window_attribute(
-                hwnd,
-                DWMWA_SYSTEMBACKDROP_TYPE as _,
-                &DWM_SYSTEMBACKDROP_TYPE::DWMSBT_DISABLE,
-            )?;
+            set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_NONE)?;
         }
     } else {
         return Err(Error::UnsupportedPlatformVersion(
@@ -287,16 +267,6 @@ unsafe fn set_window_attribute<T>(hwnd: HWND, kind: u32, object: &T) -> Result<(
 }
 
 const DWMWA_MICA_EFFECT: DWMWINDOWATTRIBUTE = 1029;
-const DWMWA_SYSTEMBACKDROP_TYPE: DWMWINDOWATTRIBUTE = 38;
-
-#[allow(unused)]
-#[repr(C)]
-enum DWM_SYSTEMBACKDROP_TYPE {
-    DWMSBT_DISABLE = 1,         // None
-    DWMSBT_MAINWINDOW = 2,      // Mica
-    DWMSBT_TRANSIENTWINDOW = 3, // Acrylic
-    DWMSBT_TABBEDWINDOW = 4,    // Tabbed
-}
 
 fn is_win7() -> bool {
     let v = windows_version::OsVersion::current();

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -148,7 +148,7 @@ pub fn apply_tabbed(hwnd: HWND, dark: Option<bool>) -> Result<(), Error> {
         }
     }
 
-    if dbg!(is_backdroptype_supported()) {
+    if is_backdroptype_supported() {
         unsafe {
             set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_TABBEDWINDOW)?;
         }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -62,7 +62,7 @@ pub fn clear_blur(hwnd: HWND) -> Result<(), Error> {
 pub fn apply_acrylic(hwnd: HWND, color: Option<Color>) -> Result<(), Error> {
     if is_backdroptype_supported() {
         unsafe {
-            set_window_attribute(
+            dwm_set_window_attribute(
                 hwnd,
                 DWMWA_SYSTEMBACKDROP_TYPE as _,
                 &DWMSBT_TRANSIENTWINDOW,
@@ -87,7 +87,7 @@ pub fn apply_acrylic(hwnd: HWND, color: Option<Color>) -> Result<(), Error> {
 pub fn clear_acrylic(hwnd: HWND) -> Result<(), Error> {
     if is_backdroptype_supported() {
         unsafe {
-            set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_NONE)?;
+            dwm_set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_NONE)?;
         }
     } else if is_swca_supported() {
         unsafe {
@@ -104,17 +104,17 @@ pub fn clear_acrylic(hwnd: HWND) -> Result<(), Error> {
 pub fn apply_mica(hwnd: HWND, dark: Option<bool>) -> Result<(), Error> {
     if let Some(dark) = dark {
         unsafe {
-            set_window_attribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE as _, &(dark as u32))?;
+            dwm_set_window_attribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE as _, &(dark as u32))?;
         }
     }
 
     if is_backdroptype_supported() {
         unsafe {
-            set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_MAINWINDOW)?;
+            dwm_set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_MAINWINDOW)?;
         }
     } else if is_undocumented_mica_supported() {
         unsafe {
-            set_window_attribute(hwnd, DWMWA_MICA_EFFECT as _, &1)?;
+            dwm_set_window_attribute(hwnd, DWMWA_MICA_EFFECT as _, &1)?;
         }
     } else {
         return Err(Error::UnsupportedPlatformVersion(
@@ -127,11 +127,11 @@ pub fn apply_mica(hwnd: HWND, dark: Option<bool>) -> Result<(), Error> {
 pub fn clear_mica(hwnd: HWND) -> Result<(), Error> {
     if is_backdroptype_supported() {
         unsafe {
-            set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_NONE)?;
+            dwm_set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_NONE)?;
         }
     } else if is_undocumented_mica_supported() {
         unsafe {
-            set_window_attribute(hwnd, DWMWA_MICA_EFFECT as _, &0)?;
+            dwm_set_window_attribute(hwnd, DWMWA_MICA_EFFECT as _, &0)?;
         }
     } else {
         return Err(Error::UnsupportedPlatformVersion(
@@ -144,13 +144,13 @@ pub fn clear_mica(hwnd: HWND) -> Result<(), Error> {
 pub fn apply_tabbed(hwnd: HWND, dark: Option<bool>) -> Result<(), Error> {
     if let Some(dark) = dark {
         unsafe {
-            set_window_attribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE as _, &(dark as u32))?;
+            dwm_set_window_attribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE as _, &(dark as u32))?;
         }
     }
 
     if is_backdroptype_supported() {
         unsafe {
-            set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_TABBEDWINDOW)?;
+            dwm_set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_TABBEDWINDOW)?;
         }
     } else {
         return Err(Error::UnsupportedPlatformVersion(
@@ -163,7 +163,7 @@ pub fn apply_tabbed(hwnd: HWND, dark: Option<bool>) -> Result<(), Error> {
 pub fn clear_tabbed(hwnd: HWND) -> Result<(), Error> {
     if is_backdroptype_supported() {
         unsafe {
-            set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_NONE)?;
+            dwm_set_window_attribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE as _, &DWMSBT_NONE)?;
         }
     } else {
         return Err(Error::UnsupportedPlatformVersion(
@@ -255,7 +255,7 @@ unsafe fn SetWindowCompositionAttribute(
     }
 }
 
-unsafe fn set_window_attribute<T>(hwnd: HWND, kind: u32, object: &T) -> Result<(), Error> {
+unsafe fn dwm_set_window_attribute<T>(hwnd: HWND, kind: u32, object: &T) -> Result<(), Error> {
     let size = std::mem::size_of::<T>() as u32;
     let result = unsafe { DwmSetWindowAttribute(hwnd, kind, object as *const _ as _, size) };
     if result == S_OK {


### PR DESCRIPTION
This PR contains two changes:

- Handle `HRESULT` values returned from `DwmSetWindowAttribute()` Win32 API so that users can handle the error properly.
- Use constants defined in `windows-sys` crate instead of defining them locally.

I confirmed the following types of vibrant windows worked on this branch:

Acrylic:

<img width="391" height="296" alt="{F3F55AF3-B065-4FD3-A523-29F81F86E856}" src="https://github.com/user-attachments/assets/6b971698-a12f-4e21-bbf0-017b60185619" />



Mica:

<img width="391" height="296" alt="{635F542E-5A86-4CCE-9C9C-1F86B2AE3B9C}" src="https://github.com/user-attachments/assets/5964f0e4-f14b-4a2d-8b31-d6f09deca5d8" />



Tabbed:

<img width="391" height="296" alt="{86DC2FEB-DB07-4830-9C05-7BEEACBD72EE}" src="https://github.com/user-attachments/assets/bd964ffb-0042-4873-98e2-c22bf4b66889" />
