### PR TITLE
feat(linux): support Wayland ext-background-effect-v1 blur

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "dlib"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading",
 ]
@@ -1595,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -2172,9 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.11"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -2186,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.11"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.8.0",
  "rustix 1.1.2",
@@ -2220,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.9"
+version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
  "bitflags 2.8.0",
  "wayland-backend",
@@ -2258,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.7"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -2269,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.7"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
@@ -2340,6 +2340,9 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "raw-window-handle",
  "tao",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-sys",
  "windows-sys 0.60.2",
  "windows-version",
  "winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,11 @@ categories = ["gui"]
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
-targets = ["x86_64-apple-darwin", "x86_64-pc-windows-msvc"]
+targets = [
+  "x86_64-apple-darwin",
+  "x86_64-pc-windows-msvc",
+  "x86_64-unknown-linux-gnu",
+]
 
 [dependencies]
 raw-window-handle = "0.6"
@@ -59,3 +63,8 @@ objc2-foundation = { version = "0.3", default-features = false, features = [
 objc2-core-foundation = { version = "0.3", default-features = false, features = [
   "std",
 ] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+wayland-client = "0.31.14"
+wayland-protocols = { version = "0.32.12", features = ["client", "staging"] }
+wayland-sys = { version = "0.31.11", features = ["client", "dlopen"] }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Make your windows vibrant.
 
 ## Platform-specific
 
-- **Linux**: Unsupported, Blur and any vibrancy effects are controlled by the compositor installed on the end-user system.
+- **Linux**: Blur is supported on Wayland when the compositor exposes `ext-background-effect-v1` with the blur capability.
 
 ## Example
 
@@ -38,7 +38,7 @@ For a more complete example of usage with [tauri](https://tauri.app/), see [`exa
 
 | Function                          |     Supported platforms      | Notes                                                                                              |
 |:----------------------------------|:----------------------------:|:---------------------------------------------------------------------------------------------------|
-| `apply_blur`&`clear_blur`         | Windows  7/10/11 (22H1 only) | Bad performance when resizing/dragging the window on Windows 11 build 22621+.                      |
+| `apply_blur`&`clear_blur`         | Windows 7/10/11 (22H1 only), Linux Wayland with `ext-background-effect-v1` blur | Bad performance when resizing/dragging the window on Windows 11 build 22621+. On Linux Wayland, returns unsupported when the compositor does not advertise blur support. |
 | `apply_acrylic`&`clear_acrylic`   |        Windows 10/11         | Bad performance when resizing/dragging the window on Windows 10 v1903+ and Windows 11 build 22000. |
 | `apply_mica`&`clear_mica`         |          Windows 11          |                                                                                                    |
 | `apply_vibrancy`&`clear_vibrancy` |    macOS 10.10 and newer     |                                                                                                    |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Platform-specific
 //!
-//! - **Linux**: Unsupported, Blur and any vibrancy effects are controlled by the compositor installed on the end-user system.
+//! - **Linux**: Blur is supported on Wayland when the compositor exposes `ext-background-effect-v1` with the blur capability.
 //!
 //! # Example
 //!
@@ -29,6 +29,9 @@ use windows_sys::core::HRESULT;
 mod macos;
 mod windows;
 
+#[cfg(target_os = "linux")]
+mod linux;
+
 pub use macos::{NSGlassEffectViewStyle, NSVisualEffectMaterial, NSVisualEffectState};
 
 #[cfg(target_os = "macos")]
@@ -37,7 +40,7 @@ pub use macos::{NSGlassEffectViewTagged, NSVisualEffectViewTagged};
 /// a tuple of RGBA colors. Each value has minimum of 0 and maximum of 255.
 pub type Color = (u8, u8, u8, u8);
 
-/// Applies blur effect to window. Works only on Windows 7, Windows 10 v1809 or newer.
+/// Applies blur effect to window. Works on Windows 7, Windows 10 v1809 or newer, and supported Linux Wayland compositors.
 ///
 /// ## WARNING:
 ///
@@ -49,7 +52,9 @@ pub type Color = (u8, u8, u8, u8);
 /// ## Platform-specific
 ///
 /// - **Windows**: *`color`* is ignored on Windows 7 and has no effect.
-/// - **Linux / macOS**: Unsupported.
+/// - **Linux**: *`color`* is ignored. Only Wayland compositors that expose `ext-background-effect-v1` with the blur capability are supported.
+/// - **macOS**: Unsupported.
+#[cfg(not(target_os = "linux"))]
 pub fn apply_blur(
     window: impl raw_window_handle::HasWindowHandle,
     #[allow(unused)] color: Option<Color>,
@@ -65,19 +70,43 @@ pub fn apply_blur(
     }
 }
 
-/// Clears blur effect applied to window. Works only on Windows 7, Windows 10 v1809 or newer.
+/// Applies blur effect to window. Works on Windows 7, Windows 10 v1809 or newer, and supported Linux Wayland compositors.
 ///
 /// ## Platform-specific
 ///
-/// - **Linux / macOS**: Unsupported.
+/// - **Linux**: *`color`* is ignored. Only Wayland compositors that expose `ext-background-effect-v1` with the blur capability are supported.
+/// - **macOS**: Unsupported.
+#[cfg(target_os = "linux")]
+pub fn apply_blur(
+    window: impl raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle,
+    #[allow(unused)] color: Option<Color>,
+) -> Result<(), Error> {
+    match (window.display_handle()?.as_raw(), window.window_handle()?.as_raw()) {
+        (
+            raw_window_handle::RawDisplayHandle::Wayland(display),
+            raw_window_handle::RawWindowHandle::Wayland(handle),
+        ) => linux::apply_blur(display, handle),
+        _ => Err(Error::UnsupportedPlatform(
+            "\"apply_blur()\" is only supported on Wayland compositors with ext-background-effect-v1 blur support.",
+        )),
+    }
+}
+
+/// Clears blur effect applied to window. Works on Windows 7, Windows 10 v1809 or newer, and supported Linux Wayland compositors.
+///
+/// ## Platform-specific
+///
+/// - **macOS**: Unsupported.
 pub fn clear_blur(window: impl raw_window_handle::HasWindowHandle) -> Result<(), Error> {
     match window.window_handle()?.as_raw() {
         #[cfg(target_os = "windows")]
         raw_window_handle::RawWindowHandle::Win32(handle) => {
             windows::clear_blur(handle.hwnd.get() as _)
         }
+        #[cfg(target_os = "linux")]
+        raw_window_handle::RawWindowHandle::Wayland(handle) => linux::clear_blur(handle),
         _ => Err(Error::UnsupportedPlatform(
-            "\"clear_blur()\" is only supported on Windows.",
+            "\"clear_blur()\" is only supported on Windows and Wayland.",
         )),
     }
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,0 +1,36 @@
+// Copyright 2019-2022 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+#![cfg(target_os = "linux")]
+
+use raw_window_handle::{WaylandDisplayHandle, WaylandWindowHandle};
+use wayland_sys::client::{wl_display, wl_proxy};
+
+use crate::Error;
+
+mod wayland;
+
+pub fn apply_blur(
+    display: WaylandDisplayHandle,
+    surface: WaylandWindowHandle,
+) -> Result<(), Error> {
+    let display = display.display.as_ptr().cast::<wl_display>();
+    let surface = surface.surface.as_ptr().cast::<wl_proxy>();
+
+    if display.is_null() || surface.is_null() {
+        return Err(wayland::unsupported());
+    }
+
+    unsafe { wayland::apply_blur(display, surface) }
+}
+
+pub fn clear_blur(surface: WaylandWindowHandle) -> Result<(), Error> {
+    let surface = surface.surface.as_ptr().cast::<wl_proxy>();
+
+    if surface.is_null() {
+        return Err(wayland::unsupported());
+    }
+
+    unsafe { wayland::clear_blur(surface) }
+}

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -5,7 +5,6 @@
 use std::{
     collections::HashMap,
     ffi::c_void,
-    ptr,
     sync::{Mutex, OnceLock},
 };
 
@@ -95,9 +94,12 @@ unsafe fn ensure_effect(
         return Ok(effect.effect as *mut wl_proxy);
     }
 
-    let mut args = [wl_argument {
-        o: surface.cast::<c_void>(),
-    }];
+    let mut args = [
+        wl_argument { n: 0 },
+        wl_argument {
+            o: surface.cast::<c_void>(),
+        },
+    ];
     let effect = unsafe {
         wayland_sys::ffi_dispatch!(
             client::wayland_client_handle(),
@@ -130,12 +132,13 @@ unsafe fn set_full_blur_region(
     effect: *mut wl_proxy,
 ) -> Result<(), Error> {
     let region = unsafe {
+        let mut args = [wl_argument { n: 0 }];
         wayland_sys::ffi_dispatch!(
             client::wayland_client_handle(),
             wl_proxy_marshal_array_constructor,
             compositor,
             wl_compositor::REQ_CREATE_REGION_OPCODE.into(),
-            ptr::null_mut(),
+            args.as_mut_ptr(),
             ffi::c_interface(wl_region::WlRegion::interface())
         )
     };

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -67,7 +67,8 @@ pub(super) unsafe fn clear_blur(surface: *mut wl_proxy) -> Result<(), Error> {
     ffi::ensure_wayland_client()?;
 
     let _operation = ffi::lock(operations());
-    let effect = ffi::lock(effects()).remove(&(surface as usize));
+    let surface_key = unsafe { SurfaceKey::new(surface) };
+    let effect = ffi::lock(effects()).remove(&surface_key);
     let Some(effect) = effect else {
         return Ok(());
     };
@@ -90,7 +91,8 @@ unsafe fn ensure_effect(
     manager: *mut wl_proxy,
 ) -> Result<*mut wl_proxy, Error> {
     let mut effects = ffi::lock(effects());
-    if let Some(effect) = effects.get(&(surface as usize)) {
+    let surface_key = unsafe { SurfaceKey::new(surface) };
+    if let Some(effect) = effects.get(&surface_key) {
         return Ok(effect.effect as *mut wl_proxy);
     }
 
@@ -117,7 +119,7 @@ unsafe fn ensure_effect(
     }
 
     effects.insert(
-        surface as usize,
+        surface_key,
         EffectState {
             display: display as usize,
             effect: effect as usize,
@@ -188,8 +190,23 @@ struct EffectState {
     effect: usize,
 }
 
-fn effects() -> &'static Mutex<HashMap<usize, EffectState>> {
-    static EFFECTS: OnceLock<Mutex<HashMap<usize, EffectState>>> = OnceLock::new();
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+struct SurfaceKey {
+    ptr: usize,
+    id: u32,
+}
+
+impl SurfaceKey {
+    unsafe fn new(surface: *mut wl_proxy) -> Self {
+        Self {
+            ptr: surface as usize,
+            id: unsafe { ffi::proxy_id(surface) },
+        }
+    }
+}
+
+fn effects() -> &'static Mutex<HashMap<SurfaceKey, EffectState>> {
+    static EFFECTS: OnceLock<Mutex<HashMap<SurfaceKey, EffectState>>> = OnceLock::new();
     EFFECTS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -1,0 +1,196 @@
+// Copyright 2019-2022 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use std::{
+    collections::HashMap,
+    ffi::c_void,
+    ptr,
+    sync::{Mutex, OnceLock},
+};
+
+use wayland_client::{
+    backend::protocol::wl_argument,
+    protocol::{wl_compositor, wl_region},
+    Proxy,
+};
+use wayland_protocols::ext::background_effect::v1::client::{
+    ext_background_effect_manager_v1,
+    ext_background_effect_surface_v1::{self, ExtBackgroundEffectSurfaceV1},
+};
+use wayland_sys::client::{self, wl_display, wl_proxy};
+
+use crate::Error;
+
+mod ffi;
+mod registry;
+
+pub(super) fn unsupported() -> Error {
+    ffi::unsupported()
+}
+
+pub(super) unsafe fn apply_blur(
+    display: *mut wl_display,
+    surface: *mut wl_proxy,
+) -> Result<(), Error> {
+    ffi::ensure_wayland_client()?;
+
+    let _operation = ffi::lock(operations());
+    let mut displays = ffi::lock(registry::displays());
+    let display_state = if let Some(display_state) = displays.get_mut(&(display as usize)) {
+        display_state
+    } else {
+        let display_state = unsafe { registry::DisplayState::new(display)? };
+        displays.insert(display as usize, display_state);
+        displays
+            .get_mut(&(display as usize))
+            .expect("display was inserted")
+    };
+
+    let compositor = unsafe { display_state.ensure_compositor()? };
+    let manager = unsafe { display_state.ensure_manager()? };
+
+    if !display_state.supports_blur() {
+        return Err(unsupported());
+    }
+
+    let effect = unsafe { ensure_effect(display, surface, manager)? };
+    unsafe {
+        set_full_blur_region(compositor, effect)?;
+        ffi::commit_surface(surface);
+        ffi::flush_display(display)?;
+    }
+
+    Ok(())
+}
+
+pub(super) unsafe fn clear_blur(surface: *mut wl_proxy) -> Result<(), Error> {
+    ffi::ensure_wayland_client()?;
+
+    let _operation = ffi::lock(operations());
+    let effect = ffi::lock(effects()).remove(&(surface as usize));
+    let Some(effect) = effect else {
+        return Ok(());
+    };
+
+    unsafe {
+        ffi::send_destructor(
+            effect.effect as *mut wl_proxy,
+            ext_background_effect_surface_v1::REQ_DESTROY_OPCODE,
+        );
+        ffi::commit_surface(surface);
+        ffi::flush_display(effect.display as *mut wl_display)?;
+    }
+
+    Ok(())
+}
+
+unsafe fn ensure_effect(
+    display: *mut wl_display,
+    surface: *mut wl_proxy,
+    manager: *mut wl_proxy,
+) -> Result<*mut wl_proxy, Error> {
+    let mut effects = ffi::lock(effects());
+    if let Some(effect) = effects.get(&(surface as usize)) {
+        return Ok(effect.effect as *mut wl_proxy);
+    }
+
+    let mut args = [wl_argument {
+        o: surface.cast::<c_void>(),
+    }];
+    let effect = unsafe {
+        wayland_sys::ffi_dispatch!(
+            client::wayland_client_handle(),
+            wl_proxy_marshal_array_constructor_versioned,
+            manager,
+            ext_background_effect_manager_v1::REQ_GET_BACKGROUND_EFFECT_OPCODE.into(),
+            args.as_mut_ptr(),
+            ffi::c_interface(ExtBackgroundEffectSurfaceV1::interface()),
+            1
+        )
+    };
+
+    if effect.is_null() {
+        return Err(ffi::request_failed());
+    }
+
+    effects.insert(
+        surface as usize,
+        EffectState {
+            display: display as usize,
+            effect: effect as usize,
+        },
+    );
+
+    Ok(effect)
+}
+
+unsafe fn set_full_blur_region(
+    compositor: *mut wl_proxy,
+    effect: *mut wl_proxy,
+) -> Result<(), Error> {
+    let region = unsafe {
+        wayland_sys::ffi_dispatch!(
+            client::wayland_client_handle(),
+            wl_proxy_marshal_array_constructor,
+            compositor,
+            wl_compositor::REQ_CREATE_REGION_OPCODE.into(),
+            ptr::null_mut(),
+            ffi::c_interface(wl_region::WlRegion::interface())
+        )
+    };
+
+    if region.is_null() {
+        return Err(ffi::request_failed());
+    }
+
+    let mut add_args = [
+        wl_argument { i: 0 },
+        wl_argument { i: 0 },
+        wl_argument {
+            i: registry::FULL_SURFACE_REGION_SIZE,
+        },
+        wl_argument {
+            i: registry::FULL_SURFACE_REGION_SIZE,
+        },
+    ];
+
+    unsafe {
+        wayland_sys::ffi_dispatch!(
+            client::wayland_client_handle(),
+            wl_proxy_marshal_array,
+            region,
+            wl_region::REQ_ADD_OPCODE.into(),
+            add_args.as_mut_ptr()
+        );
+
+        let mut set_args = [wl_argument {
+            o: region.cast::<c_void>(),
+        }];
+        wayland_sys::ffi_dispatch!(
+            client::wayland_client_handle(),
+            wl_proxy_marshal_array,
+            effect,
+            ext_background_effect_surface_v1::REQ_SET_BLUR_REGION_OPCODE.into(),
+            set_args.as_mut_ptr()
+        );
+        ffi::send_destructor(region, wl_region::REQ_DESTROY_OPCODE);
+    }
+
+    Ok(())
+}
+
+struct EffectState {
+    display: usize,
+    effect: usize,
+}
+
+fn effects() -> &'static Mutex<HashMap<usize, EffectState>> {
+    static EFFECTS: OnceLock<Mutex<HashMap<usize, EffectState>>> = OnceLock::new();
+    EFFECTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn operations() -> &'static Mutex<()> {
+    static OPERATIONS: OnceLock<Mutex<()>> = OnceLock::new();
+    OPERATIONS.get_or_init(|| Mutex::new(()))
+}

--- a/src/linux/wayland/ffi.rs
+++ b/src/linux/wayland/ffi.rs
@@ -1,0 +1,119 @@
+// Copyright 2019-2022 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use std::{
+    ptr,
+    sync::{Mutex, MutexGuard},
+};
+
+use wayland_client::{
+    backend::protocol::{wl_interface, Interface},
+    protocol::{wl_compositor, wl_surface},
+};
+use wayland_sys::client::{self, wl_display, wl_event_queue, wl_proxy};
+
+use crate::Error;
+
+const APPLY_BLUR_UNSUPPORTED: &str =
+    "\"apply_blur()\" requires a Wayland compositor with ext-background-effect-v1 blur support.";
+const WAYLAND_QUERY_FAILED: &str =
+    "\"apply_blur()\" could not query Wayland compositor blur support.";
+const WAYLAND_REQUEST_FAILED: &str = "\"apply_blur()\" could not request Wayland compositor blur.";
+
+pub(super) fn ensure_wayland_client() -> Result<(), Error> {
+    if client::is_lib_available() {
+        Ok(())
+    } else {
+        Err(unsupported())
+    }
+}
+
+pub(super) unsafe fn release_compositor(proxy: *mut wl_proxy, version: u32) {
+    if version >= wl_compositor::REQ_RELEASE_SINCE {
+        unsafe {
+            send_destructor(proxy, wl_compositor::REQ_RELEASE_OPCODE);
+        }
+    } else {
+        unsafe {
+            wayland_sys::ffi_dispatch!(client::wayland_client_handle(), wl_proxy_destroy, proxy);
+        }
+    }
+}
+
+pub(super) unsafe fn send_destructor(proxy: *mut wl_proxy, opcode: u16) {
+    unsafe {
+        wayland_sys::ffi_dispatch!(
+            client::wayland_client_handle(),
+            wl_proxy_marshal_array,
+            proxy,
+            opcode.into(),
+            ptr::null_mut()
+        );
+        wayland_sys::ffi_dispatch!(client::wayland_client_handle(), wl_proxy_destroy, proxy);
+    }
+}
+
+pub(super) unsafe fn commit_surface(surface: *mut wl_proxy) {
+    unsafe {
+        wayland_sys::ffi_dispatch!(
+            client::wayland_client_handle(),
+            wl_proxy_marshal_array,
+            surface,
+            wl_surface::REQ_COMMIT_OPCODE.into(),
+            ptr::null_mut()
+        );
+    }
+}
+
+pub(super) unsafe fn flush_display(display: *mut wl_display) -> Result<(), Error> {
+    let result = unsafe {
+        wayland_sys::ffi_dispatch!(client::wayland_client_handle(), wl_display_flush, display)
+    };
+    if result < 0 {
+        return Err(request_failed());
+    }
+
+    Ok(())
+}
+
+pub(super) unsafe fn roundtrip_queue(
+    display: *mut wl_display,
+    queue: *mut wl_event_queue,
+) -> Result<(), Error> {
+    let result = unsafe {
+        wayland_sys::ffi_dispatch!(
+            client::wayland_client_handle(),
+            wl_display_roundtrip_queue,
+            display,
+            queue
+        )
+    };
+    if result < 0 {
+        return Err(query_failed());
+    }
+
+    Ok(())
+}
+
+pub(super) fn c_interface(interface: &'static Interface) -> *const wl_interface {
+    interface
+        .c_ptr
+        .expect("generated Wayland interfaces include C metadata")
+}
+
+pub(super) fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(|error| error.into_inner())
+}
+
+pub(super) fn unsupported() -> Error {
+    Error::UnsupportedPlatformVersion(APPLY_BLUR_UNSUPPORTED)
+}
+
+pub(super) fn query_failed() -> Error {
+    Error::UnsupportedPlatformVersion(WAYLAND_QUERY_FAILED)
+}
+
+pub(super) fn request_failed() -> Error {
+    Error::UnsupportedPlatformVersion(WAYLAND_REQUEST_FAILED)
+}

--- a/src/linux/wayland/ffi.rs
+++ b/src/linux/wayland/ffi.rs
@@ -96,6 +96,10 @@ pub(super) unsafe fn roundtrip_queue(
     Ok(())
 }
 
+pub(super) unsafe fn proxy_id(proxy: *mut wl_proxy) -> u32 {
+    unsafe { wayland_sys::ffi_dispatch!(client::wayland_client_handle(), wl_proxy_get_id, proxy) }
+}
+
 pub(super) fn c_interface(interface: &'static Interface) -> *const wl_interface {
     interface
         .c_ptr

--- a/src/linux/wayland/registry.rs
+++ b/src/linux/wayland/registry.rs
@@ -1,0 +1,475 @@
+// Copyright 2019-2022 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use std::{
+    collections::HashMap,
+    ffi::{c_char, c_void, CStr},
+    ptr,
+    sync::{Mutex, OnceLock},
+};
+
+use wayland_client::{
+    backend::protocol::{wl_argument, wl_interface},
+    protocol::{wl_compositor, wl_display as wl_display_proto, wl_registry},
+    Proxy,
+};
+use wayland_protocols::ext::background_effect::v1::client::ext_background_effect_manager_v1::{
+    self, ExtBackgroundEffectManagerV1,
+};
+use wayland_sys::client::{self, wl_display, wl_event_queue, wl_proxy};
+
+use crate::Error;
+
+use super::ffi;
+
+pub(super) const FULL_SURFACE_REGION_SIZE: i32 = i32::MAX / 2;
+
+const BLUR_CAPABILITY: u32 = 1;
+const WL_COMPOSITOR_NAME: &[u8] = b"wl_compositor";
+const EXT_BACKGROUND_EFFECT_MANAGER_NAME: &[u8] = b"ext_background_effect_manager_v1";
+
+pub(super) struct DisplayState {
+    display: usize,
+    queue: usize,
+    registry: usize,
+    data: Box<RegistryData>,
+    compositor: Option<BoundProxy>,
+    manager: Option<BoundProxy>,
+}
+
+impl DisplayState {
+    pub(super) unsafe fn new(display: *mut wl_display) -> Result<Self, Error> {
+        let queue = unsafe {
+            wayland_sys::ffi_dispatch!(
+                client::wayland_client_handle(),
+                wl_display_create_queue,
+                display
+            )
+        };
+        if queue.is_null() {
+            return Err(ffi::query_failed());
+        }
+
+        let display_wrapper = unsafe {
+            wayland_sys::ffi_dispatch!(
+                client::wayland_client_handle(),
+                wl_proxy_create_wrapper,
+                display.cast::<wl_proxy>()
+            )
+        };
+        if display_wrapper.is_null() {
+            unsafe {
+                wayland_sys::ffi_dispatch!(
+                    client::wayland_client_handle(),
+                    wl_event_queue_destroy,
+                    queue
+                );
+            }
+            return Err(ffi::query_failed());
+        }
+
+        unsafe {
+            wayland_sys::ffi_dispatch!(
+                client::wayland_client_handle(),
+                wl_proxy_set_queue,
+                display_wrapper,
+                queue
+            );
+        }
+
+        let registry = unsafe {
+            wayland_sys::ffi_dispatch!(
+                client::wayland_client_handle(),
+                wl_proxy_marshal_array_constructor,
+                display_wrapper,
+                wl_display_proto::REQ_GET_REGISTRY_OPCODE.into(),
+                ptr::null_mut(),
+                ffi::c_interface(wl_registry::WlRegistry::interface())
+            )
+        };
+
+        unsafe {
+            wayland_sys::ffi_dispatch!(
+                client::wayland_client_handle(),
+                wl_proxy_wrapper_destroy,
+                display_wrapper
+            );
+        }
+
+        if registry.is_null() {
+            unsafe {
+                wayland_sys::ffi_dispatch!(
+                    client::wayland_client_handle(),
+                    wl_event_queue_destroy,
+                    queue
+                );
+            }
+            return Err(ffi::query_failed());
+        }
+
+        let data = Box::<RegistryData>::default();
+        unsafe {
+            wayland_sys::ffi_dispatch!(
+                client::wayland_client_handle(),
+                wl_proxy_set_queue,
+                registry,
+                queue
+            );
+            let add_listener_result = wayland_sys::ffi_dispatch!(
+                client::wayland_client_handle(),
+                wl_proxy_add_listener,
+                registry,
+                &REGISTRY_LISTENER as *const RegistryListener as *mut extern "C" fn(),
+                data.as_ref() as *const RegistryData as *mut c_void
+            );
+            if add_listener_result != 0 {
+                destroy_proxy(registry);
+                destroy_queue(queue);
+                return Err(ffi::query_failed());
+            }
+        }
+
+        let state = Self {
+            display: display as usize,
+            queue: queue as usize,
+            registry: registry as usize,
+            data,
+            compositor: None,
+            manager: None,
+        };
+
+        unsafe {
+            state.roundtrip()?;
+        }
+
+        Ok(state)
+    }
+
+    pub(super) unsafe fn ensure_compositor(&mut self) -> Result<*mut wl_proxy, Error> {
+        unsafe {
+            self.roundtrip()?;
+        }
+
+        let global = self.globals().compositor.ok_or_else(ffi::unsupported)?;
+        if let Some(compositor) = self.compositor {
+            if compositor.name == global.name {
+                return Ok(compositor.proxy());
+            }
+            unsafe {
+                ffi::release_compositor(compositor.proxy(), compositor.version);
+            }
+        }
+
+        let version = global
+            .version
+            .min(wl_compositor::WlCompositor::interface().version);
+        let compositor = unsafe {
+            bind_global(
+                self.registry(),
+                global.name,
+                version,
+                ffi::c_interface(wl_compositor::WlCompositor::interface()),
+            )?
+        };
+        unsafe {
+            self.set_queue(compositor);
+        }
+
+        self.compositor = Some(BoundProxy {
+            name: global.name,
+            version,
+            ptr: compositor as usize,
+        });
+
+        Ok(compositor)
+    }
+
+    pub(super) unsafe fn ensure_manager(&mut self) -> Result<*mut wl_proxy, Error> {
+        unsafe {
+            self.roundtrip()?;
+        }
+
+        let global = self
+            .globals()
+            .background_effect_manager
+            .ok_or_else(ffi::unsupported)?;
+
+        if let Some(manager) = self.manager {
+            if manager.name == global.name {
+                return Ok(manager.proxy());
+            }
+            unsafe {
+                ffi::send_destructor(
+                    manager.proxy(),
+                    ext_background_effect_manager_v1::REQ_DESTROY_OPCODE,
+                );
+            }
+        }
+
+        let version = global
+            .version
+            .min(ExtBackgroundEffectManagerV1::interface().version);
+        let manager = unsafe {
+            bind_global(
+                self.registry(),
+                global.name,
+                version,
+                ffi::c_interface(ExtBackgroundEffectManagerV1::interface()),
+            )?
+        };
+        unsafe {
+            self.set_queue(manager);
+        }
+
+        *ffi::lock(&self.data.capabilities) = None;
+
+        let add_listener_result = unsafe {
+            wayland_sys::ffi_dispatch!(
+                client::wayland_client_handle(),
+                wl_proxy_add_listener,
+                manager,
+                &BACKGROUND_EFFECT_MANAGER_LISTENER as *const BackgroundEffectManagerListener
+                    as *mut extern "C" fn(),
+                self.data.as_ref() as *const RegistryData as *mut c_void
+            )
+        };
+        if add_listener_result != 0 {
+            unsafe {
+                ffi::send_destructor(
+                    manager,
+                    ext_background_effect_manager_v1::REQ_DESTROY_OPCODE,
+                );
+            }
+            return Err(ffi::query_failed());
+        }
+
+        self.manager = Some(BoundProxy {
+            name: global.name,
+            version,
+            ptr: manager as usize,
+        });
+
+        unsafe {
+            self.roundtrip()?;
+        }
+
+        Ok(manager)
+    }
+
+    pub(super) fn supports_blur(&self) -> bool {
+        let capabilities = *ffi::lock(&self.data.capabilities);
+        capabilities.is_some_and(|capabilities| capabilities & BLUR_CAPABILITY == BLUR_CAPABILITY)
+    }
+
+    fn globals(&self) -> Globals {
+        *ffi::lock(&self.data.globals)
+    }
+
+    fn registry(&self) -> *mut wl_proxy {
+        self.registry as *mut wl_proxy
+    }
+
+    unsafe fn set_queue(&self, proxy: *mut wl_proxy) {
+        unsafe {
+            wayland_sys::ffi_dispatch!(
+                client::wayland_client_handle(),
+                wl_proxy_set_queue,
+                proxy,
+                self.queue as *mut wl_event_queue
+            );
+        }
+    }
+
+    unsafe fn roundtrip(&self) -> Result<(), Error> {
+        unsafe {
+            ffi::roundtrip_queue(
+                self.display as *mut wl_display,
+                self.queue as *mut wl_event_queue,
+            )
+        }
+    }
+}
+
+impl Drop for DisplayState {
+    fn drop(&mut self) {
+        unsafe {
+            if let Some(manager) = self.manager.take() {
+                ffi::send_destructor(
+                    manager.proxy(),
+                    ext_background_effect_manager_v1::REQ_DESTROY_OPCODE,
+                );
+            }
+
+            if let Some(compositor) = self.compositor.take() {
+                ffi::release_compositor(compositor.proxy(), compositor.version);
+            }
+
+            destroy_proxy(self.registry());
+            destroy_queue(self.queue as *mut wl_event_queue);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct BoundProxy {
+    name: u32,
+    version: u32,
+    ptr: usize,
+}
+
+impl BoundProxy {
+    fn proxy(self) -> *mut wl_proxy {
+        self.ptr as *mut wl_proxy
+    }
+}
+
+#[derive(Default)]
+struct RegistryData {
+    globals: Mutex<Globals>,
+    capabilities: Mutex<Option<u32>>,
+}
+
+#[derive(Default, Clone, Copy)]
+struct Globals {
+    compositor: Option<Global>,
+    background_effect_manager: Option<Global>,
+}
+
+#[derive(Clone, Copy)]
+struct Global {
+    name: u32,
+    version: u32,
+}
+
+#[repr(C)]
+struct RegistryListener {
+    global: unsafe extern "C" fn(*mut c_void, *mut wl_proxy, u32, *const c_char, u32),
+    global_remove: unsafe extern "C" fn(*mut c_void, *mut wl_proxy, u32),
+}
+
+static REGISTRY_LISTENER: RegistryListener = RegistryListener {
+    global: registry_global,
+    global_remove: registry_global_remove,
+};
+
+#[repr(C)]
+struct BackgroundEffectManagerListener {
+    capabilities: unsafe extern "C" fn(*mut c_void, *mut wl_proxy, u32),
+}
+
+static BACKGROUND_EFFECT_MANAGER_LISTENER: BackgroundEffectManagerListener =
+    BackgroundEffectManagerListener {
+        capabilities: background_effect_manager_capabilities,
+    };
+
+unsafe extern "C" fn registry_global(
+    data: *mut c_void,
+    _registry: *mut wl_proxy,
+    name: u32,
+    interface: *const c_char,
+    version: u32,
+) {
+    if data.is_null() || interface.is_null() {
+        return;
+    }
+
+    let data = unsafe { &*(data as *const RegistryData) };
+    let interface = unsafe { CStr::from_ptr(interface) }.to_bytes();
+
+    let mut globals = ffi::lock(&data.globals);
+    if interface == WL_COMPOSITOR_NAME {
+        globals.compositor = Some(Global { name, version });
+    } else if interface == EXT_BACKGROUND_EFFECT_MANAGER_NAME {
+        globals.background_effect_manager = Some(Global { name, version });
+    }
+}
+
+unsafe extern "C" fn registry_global_remove(
+    data: *mut c_void,
+    _registry: *mut wl_proxy,
+    name: u32,
+) {
+    if data.is_null() {
+        return;
+    }
+
+    let data = unsafe { &*(data as *const RegistryData) };
+    let mut globals = ffi::lock(&data.globals);
+    if globals.compositor.map(|global| global.name) == Some(name) {
+        globals.compositor = None;
+    }
+    if globals.background_effect_manager.map(|global| global.name) == Some(name) {
+        globals.background_effect_manager = None;
+        *ffi::lock(&data.capabilities) = None;
+    }
+}
+
+unsafe extern "C" fn background_effect_manager_capabilities(
+    data: *mut c_void,
+    _manager: *mut wl_proxy,
+    flags: u32,
+) {
+    if data.is_null() {
+        return;
+    }
+
+    let data = unsafe { &*(data as *const RegistryData) };
+    *ffi::lock(&data.capabilities) = Some(flags);
+}
+
+unsafe fn bind_global(
+    registry: *mut wl_proxy,
+    name: u32,
+    version: u32,
+    interface: *const wl_interface,
+) -> Result<*mut wl_proxy, Error> {
+    let mut args = unsafe {
+        [
+            wl_argument { u: name },
+            wl_argument {
+                s: (*interface).name,
+            },
+            wl_argument { u: version },
+        ]
+    };
+
+    let proxy = unsafe {
+        wayland_sys::ffi_dispatch!(
+            client::wayland_client_handle(),
+            wl_proxy_marshal_array_constructor_versioned,
+            registry,
+            wl_registry::REQ_BIND_OPCODE.into(),
+            args.as_mut_ptr(),
+            interface,
+            version
+        )
+    };
+
+    if proxy.is_null() {
+        return Err(ffi::query_failed());
+    }
+
+    Ok(proxy)
+}
+
+pub(super) fn displays() -> &'static Mutex<HashMap<usize, DisplayState>> {
+    static DISPLAYS: OnceLock<Mutex<HashMap<usize, DisplayState>>> = OnceLock::new();
+    DISPLAYS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+unsafe fn destroy_proxy(proxy: *mut wl_proxy) {
+    unsafe {
+        wayland_sys::ffi_dispatch!(client::wayland_client_handle(), wl_proxy_destroy, proxy);
+    }
+}
+
+unsafe fn destroy_queue(queue: *mut wl_event_queue) {
+    unsafe {
+        wayland_sys::ffi_dispatch!(
+            client::wayland_client_handle(),
+            wl_event_queue_destroy,
+            queue
+        );
+    }
+}

--- a/src/linux/wayland/registry.rs
+++ b/src/linux/wayland/registry.rs
@@ -5,7 +5,6 @@
 use std::{
     collections::HashMap,
     ffi::{c_char, c_void, CStr},
-    ptr,
     sync::{Mutex, OnceLock},
 };
 
@@ -79,12 +78,13 @@ impl DisplayState {
         }
 
         let registry = unsafe {
+            let mut args = [wl_argument { n: 0 }];
             wayland_sys::ffi_dispatch!(
                 client::wayland_client_handle(),
                 wl_proxy_marshal_array_constructor,
                 display_wrapper,
                 wl_display_proto::REQ_GET_REGISTRY_OPCODE.into(),
-                ptr::null_mut(),
+                args.as_mut_ptr(),
                 ffi::c_interface(wl_registry::WlRegistry::interface())
             )
         };
@@ -431,6 +431,7 @@ unsafe fn bind_global(
                 s: (*interface).name,
             },
             wl_argument { u: version },
+            wl_argument { n: 0 },
         ]
     };
 


### PR DESCRIPTION
Added Linux Wayland support for `apply_blur` using `ext-background-effect-v1`. It returns unsupported when the compositor does not advertise blur support. It also tracks background-effect objects per Wayland surface id so cleared/destroyed surfaces do not collide with reused pointers. Closes #207